### PR TITLE
Add dist:32 npm script for building 32 bit setup exe

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "electron ./",
     "dist": "electron-builder",
+    "dist:32": "npm run dist -- --ia32 -c.artifactName=${productName}-32bit-setup-${version}.${ext}",
     "win": "electron-builder --windows portable",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Submitting this because a pasting a link to my self built 32bit installer on a random file sharing site in discord doesn't feel like a very proper distribution method 😅 

Not sure how you are generating the release files, but this adds an npm script to generate a 32 bit installer (with a different filename, so it doesn't overwrite the x64 one)

```
npm run dist:32
```

It should inherit any future additions to the `dist` script, since it just calls that one and adds a couple extra arguments.

I could have told electron-builder to generate an exe for both x64 and ia32, but it only makes a single exe which is twice as big :/
I couldn't figure out an artifact name in the build config that would include the arch we are building for, there is a ${arch} but it doesn't seem to work with nsis for some reason.