### PR TITLE
Add AppImage build for Linux distributions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pokeclicker-desktop",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.5.9",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "electron ./",
     "dist:32": "electron-builder --ia32",
-    "dist:64": "electron-builder --x64 -c.artifactName=${productName}-64bit-setup-${version}.${ext}",
+    "dist:64": "electron-builder --x64",
     "win": "electron-builder --windows portable",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -30,6 +30,7 @@
   },
   "build": {
     "productName": "PokéClicker",
+    "artifactName": "${productName}-${arch}-setup-${version}.${ext}",
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
@@ -40,9 +41,8 @@
     "linux": {
       "category": "Game",
       "icon": "icon_512x512.png",
-      "target": "deb"
+      "target": ["deb", "AppImage"]
     },
-    "deb": {},
     "appId": "pokeclicker.desktop"
   }
 }


### PR DESCRIPTION
AppImage is a Linux build format compatible with more Linux distributions. While it is way less integrated into the system than specific builds, AppImage can be launched without installing them and does not require system dependencies.

As a Fedora user, I can't use the .deb package, limited to Debian based distributions (i.e. Ubuntu, Pop! OS). The AppImage allows having a desktop version of the game on more distributions (I.e. Arch, Fedora, OpenSuse). The list of compatible distributions are listed on their website : https://appimage.org/

**Size**
As the AppImage must include more files/dependencies, the build weights 30MB more than the Debian package.

**Linux Integration**
An AppImage build does not need to be installed. Just a double click on the file is enough to launch it.
However, as there is no install, the system integration is almost non-existent: adding the application to the system menu is a manual step (via menulibre or other tools) and requires an 'external' icon selection.

**Why not RPM**

I did not include the build of RPM packages for RedHat based distributions:
- it seems to require additional build tools (rpmbuild) I hadn't installed
- The RPM package I built refuses to install due to a conflict with some Python3 library and I didn't take the time to investigate.

**Tested so far**

OS : Fedora 37 with KDE 5.27 / Gnome 43.3

- Desktop Notifications works, but there is no icon in it
- Discord Rich Presence works