### PR TITLE
Mac build

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,21 @@ A web wrapper for Pokeclicker
 - Discord rich presence (customizable)
 
 ![](https://i.imgur.com/5QQfoiZ.png)
+
+## Installing
+
+### Windows
+Download and run `PokeClicker.Setup.{version}.exe` from [the latest release](https://github.com/RedSparr0w/Pokeclicker-desktop/releases/latest)
+
+### Linux
+Download and install `pokeclicker-desktop_{version}_amd64.deb` from [the latest release](https://github.com/RedSparr0w/Pokeclicker-desktop/releases/latest)
+
+### Mac
+
+Using [Homebrew](https://brew.sh/)
+```sh
+brew tap pokeclicker/tap
+brew install pokeclicker-desktop
+```
+
+You may need to launch the app the first time (and after any update) from your Applications folder in Finder, subsequent launches should work from Spotlight.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dist:32": "electron-builder --ia32",
     "dist:64": "electron-builder --x64 -c.artifactName=${productName}-64bit-setup-${version}.${ext}",
     "win": "electron-builder --windows portable",
+    "mac": "electron-builder --mac",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": {
@@ -41,6 +42,10 @@
       "category": "Game",
       "icon": "icon_512x512.png",
       "target": "deb"
+    },
+    "mac": {
+        "target": "zip",
+        "icon": "icon_512x512.png"
     },
     "deb": {},
     "appId": "pokeclicker.desktop"


### PR DESCRIPTION
I tested creating a mac build on my arch install, and pushed the created zip to a release on my fork of this repo [here](https://github.com/Aegyo/Pokeclicker-desktop/releases/tag/v1.2.1-alpha)

I've also created a homebrew tap in the pokeclicker org ([link](https://github.com/pokeclicker/homebrew-tap)) which is currently setup to pull that release from my fork, but we can update it on next release to grab from here. I haven't been able to test how it handles the auto-updating (may need manual version bumps over on that repo, there is a tool for this I think), but I was able to install the client on my mac with the instructions I've added to the repo (M1 chip, macOS Ventura 13.3.1)

Related to #16